### PR TITLE
Adding npm version 5 support

### DIFF
--- a/bin/nom
+++ b/bin/nom
@@ -6,17 +6,25 @@ var log = require('verbalize');
 var argv = require('minimist')(process.argv.slice(2));
 var exec = require('child_process').exec
 var Spinner = require('cli-spinner').Spinner;
+var semver = require('semver');
 
 var spinner = new Spinner('nom nom nom... %s');
 spinner.start();
 
-exec('rm -rf node_modules && npm cache clean && npm install', function(err, stdout, stderr) {
+exec('npm -v', function(err, stdout, stderr) {
   if (err) throw err;
-  spinner.stop();
 
-  if (argv.log) { 
-    console.log(stdout);
-  } else {
-    console.log('done!');
-  }
+  var cacheArg = (semver.lt(stdout, '5.0.0') ? ' clean' : ' verify');
+  var command = 'rm -rf node_modules && npm cache' + cacheArg + ' && npm install';
+  exec(command, function(err, stdout, stderr) {
+    if (err) throw err;
+    spinner.stop();
+
+    if (argv.log) {
+      console.log(stdout);
+    } else {
+      console.log('done!');
+    }
+  });
+
 });

--- a/bin/nombom
+++ b/bin/nombom
@@ -6,36 +6,41 @@ var log = require('verbalize');
 var argv = require('minimist')(process.argv.slice(2));
 var exec = require('child_process').exec
 var Spinner = require('cli-spinner').Spinner;
+var semver = require('semver');
 
 if (fs.existsSync('package.json')) {
   var nomSpinner = new Spinner('nom nom nom... %s');
   nomSpinner.start();
 
-  exec('rm -rf node_modules && npm cache clean && npm install', function(err, stdout, stderr) {
+  exec('npm -v', function(err, stdout, stderr) {
     if (err) throw err;
-    nomSpinner.stop();
-    process.stdout.write('\n')
 
-    if (argv.log) { console.log(stdout); }
+    var cacheArg = (semver.lt(stdout, '5.0.0') ? ' clean' : ' verify');
+    var command = 'rm -rf node_modules && npm cache' + cacheArg + ' && npm install';
+    exec(command, function(err, stdout, stderr) {
+      if (err) throw err;
+      nomSpinner.stop();
+      process.stdout.write('\n')
 
-    if (fs.existsSync('bower.json')) {
-      var bomSpinner = new Spinner('bom bom bom... %s');
-      bomSpinner.start();
+      if (argv.log) { console.log(stdout); }
 
-      exec('rm -rf bower_components && bower cache clean && bower install', function(err, stdout, stderr) {
-        if (err) throw err;
-        bomSpinner.stop();
-        process.stdout.write('\n')
+      if (fs.existsSync('bower.json')) {
+        var bomSpinner = new Spinner('bom bom bom... %s');
+        bomSpinner.start();
 
-        if (argv.log) { console.log(stdout); }
+        exec('rm -rf bower_components && bower cache clean && bower install', function(err, stdout, stderr) {
+          if (err) throw err;
+          bomSpinner.stop();
+          process.stdout.write('\n')
 
+          if (argv.log) { console.log(stdout); }
+
+          console.log('done!');
+        });
+
+      } else {
         console.log('done!');
-      });
-
-    } else {
-      console.log('done!');
-    }
+      }
+    });
   });
 }
-
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nombom",
   "description": "Nom nom nom",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "homepage": "https://github.com/pzuraq/nombom",
   "author": {
     "name": "pzuraq",
@@ -43,6 +43,7 @@
   "dependencies": {
     "cli-spinner": "^0.2.0",
     "minimist": "~0.0.8",
+    "semver": "^5.4.1",
     "verbalize": "~0.1.1"
   }
 }


### PR DESCRIPTION
Using 'npm cache verify' for npm@5. Prior npm versions will continue to use ‘npm cache clean’.
Resolves #3